### PR TITLE
Integrate with Github Gists to allow for publishing

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-pn.srg.id.au

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+pn.srg.id.au

--- a/css/style.css
+++ b/css/style.css
@@ -175,7 +175,7 @@ body.pynode .pageBanner {
 }
 
 body.pynode .pageTopWrapper {
-    height: 450px;
+    height: 500px;
     position: relative;
 }
 

--- a/index.html
+++ b/index.html
@@ -115,30 +115,42 @@
 
             // Get the gist id from the url search params
             const gist_slug = searchParams.get("gist");
+
+            console.log("Gist parameter found, value: " + gist_slug);
+
             localStorage.setItem("code", "");
 
             // Should be in the form username-gistid
             // e.g. jdoe-83efe8c19b9dd6489167e67464030d04
-            if (gist_slug.includes("-")) {
+            if (gist_slug.includes("-") && gist_slug.split("-")[1].length === 32) {
+
+                console.log("Gist slug seems to be valid, fetching...");
 
                 // Fetch the raw content of the gist
                 fetch(`https://gist.githubusercontent.com/${gist_slug.replace("-", "/")}/raw`).then(r => {
 
+                    console.log("Response status: " + r.status);
+
                     if (r.status == 200) {
-                        localStorage.removeItem("code");
+                        localStorage.setItem("code", "");
                         return r.text()
                     } else {
                         read_storage = true;
                         if (editor_exists) {
                             loadCode("# Couldn't load gist  (http != 200).\n# Please try again later.\n\n")
                         }
+                        return null;
                     }
 
                 }).then(t => {
                     if (t) {
 
+                        console.log("Gist content fetched, setting code...");
+
                         // Add a small prefix to inform the user whether the gist was loaded from the server or from local storage
                         editor_text = `# Content loaded from Github gist on ${new Date().toLocaleString()}\n# https://gist.github.com/${gist_slug.replace("-", "/")}\n\n${t}`;
+
+                        console.log(editor_text);
 
                         if (editor_exists) {
                             editor.setValue(editor_text, -1);

--- a/index.html
+++ b/index.html
@@ -155,6 +155,8 @@
                         if (editor_exists) {
                             editor.setValue(editor_text, -1);
                             saveCode();
+                        } else {
+                            localStorage.setItem("code", editor_text);
                         }
                     }
                 }).catch(e => {

--- a/index.html
+++ b/index.html
@@ -86,34 +86,67 @@
     <script>
         var read_storage = true;
         var project_src;
-        var query = window.location.search.substring(1);
-        if (query.length > 0) {
-            var pair = query.split("=");
-            if (pair.length == 2 && pair[0] == "project") {
-                project_name = pair[1];
-                read_storage = false;
-                var client = new XMLHttpRequest();
-                client.open("GET", "pynode_projects/" + project_name + ".py");
-                client.onreadystatechange = function () {
-                    if (client.readyState == 4) {
-                        project_src = client.responseText;
-                        if (editor_exists) {
-                            editor.setValue(project_src, -1);
-                        }
+
+        const searchParams = new URLSearchParams(window.location.search);
+
+        if (searchParams.get("project")) {
+            project_name = pair[1];
+            read_storage = false;
+            var client = new XMLHttpRequest();
+            client.open("GET", "pynode_projects/" + project_name + ".py");
+            client.onreadystatechange = function () {
+                if (client.readyState == 4) {
+                    project_src = client.responseText;
+                    if (editor_exists) {
+                        editor.setValue(project_src, -1);
                     }
-                    else {
+                }
+                else {
+                    read_storage = true;
+                    if (editor_exists) {
+                        loadCode()
+                    }
+                }
+            };
+            client.send();
+        } else if (searchParams.get("gist")) {
+
+            const gist_slug = searchParams.get("gist");
+
+            // Should be in the form username-gistid
+            if (gist_slug.includes("-")) {
+                fetch(`https://gist.githubusercontent.com/${gist_slug.replace("-", "/")}/raw`).then(r => {
+
+                    if (r.status == 200) {
+                        return r.text()
+                    } else {
                         read_storage = true;
                         if (editor_exists) {
                             loadCode()
                         }
                     }
-                };
-                client.send();
+
+                }).then(t => {
+                    if (t) {
+                        editor_text = `# Content loaded from Github gist: https://gist.github.com/${gist_slug}\n\n${t}`;
+
+                        if (editor_exists) {
+                            editor.setValue(editor_text, -1);
+                        }
+                    }
+                })
+            } else {
+                read_storage = true;
+                if (editor_exists) {
+                    loadCode()
+                }
             }
-            var url = window.location.href;
-            var newUrl = url.substring(url.lastIndexOf('/') + 1).split("?")[0];
-            window.history.pushState("object or string", "Title", "" + newUrl);
+
         }
+
+        var url = window.location.href;
+        var newUrl = url.substring(url.lastIndexOf('/') + 1).split("?")[0];
+        window.history.pushState("object or string", "Title", "" + newUrl);
     </script>
 </head>
 
@@ -150,7 +183,13 @@
                         <li>
                             <p><a href="#" onclick="openCode('tictactoe'); return false;">Tic Tac Toe</a></p>
                         </li>
+                        <li>
+                            <p>
+                                <input type="url" id="gisturl" placeholder="https://gist.github.com/username/83efe8c19b9dd6489167e67464030d04" /> <button onclick="">Load Github Gist</button>
+                            </p>
+                        </li>
                     </ul>
+
                     <br>
                     <p>Note: You can now use <a href="https://github.com/algrx/algorithmx">AlgorithmX</a> to create even better network visualizations!</p>
                 </div>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,20 @@
                             editor.setValue(editor_text, -1);
                             saveCode();
                         } else {
-                            localStorage.setItem("code", editor_text);
+
+                            console.log("The editor hasn't loaded yet. Retrying every second.");
+
+                            window.loadInGistInterval = setInterval(() => {
+                                if (editor_exists) {
+                                    console.log("The editor loaded, setting code...");
+                                    editor.setValue(editor_text, -1);
+                                    saveCode();
+                                    clearInterval(window.loadInGistInterval);
+                                } else {
+                                    console.log("The editor hasn't loaded yet.");
+                                }
+                            }, 100);
+
                         }
                     }
                 }).catch(e => {

--- a/index.html
+++ b/index.html
@@ -111,9 +111,11 @@
             client.send();
         } else if (searchParams.get("gist")) {
 
+            read_storage = false;
             const gist_slug = searchParams.get("gist");
 
             // Should be in the form username-gistid
+            // e.g. jdoe-83efe8c19b9dd6489167e67464030d04
             if (gist_slug.includes("-")) {
                 fetch(`https://gist.githubusercontent.com/${gist_slug.replace("-", "/")}/raw`).then(r => {
 
@@ -128,7 +130,7 @@
 
                 }).then(t => {
                     if (t) {
-                        editor_text = `# Content loaded from Github gist: https://gist.github.com/${gist_slug}\n\n${t}`;
+                        editor_text = `# Content loaded from Github gist on ${new Date().toLocaleString()}\n# https://gist.github.com/${gist_slug.replace("-", "/")}\n\n${t}`;
 
                         if (editor_exists) {
                             editor.setValue(editor_text, -1);
@@ -147,6 +149,17 @@
         var url = window.location.href;
         var newUrl = url.substring(url.lastIndexOf('/') + 1).split("?")[0];
         window.history.pushState("object or string", "Title", "" + newUrl);
+
+        function loadGistFromUrl() {
+
+            const url = document.getElementById("gisturl").value;
+            const slug = url.replace("https://gist.github.com/", "").replace("/", "-");
+
+            const newUrl = `${location.protocol}//${location.hostname}/?gist=${slug}`;
+            window.location.href = newUrl;
+
+        }
+
     </script>
 </head>
 
@@ -185,7 +198,7 @@
                         </li>
                         <li>
                             <p>
-                                <input type="url" id="gisturl" placeholder="https://gist.github.com/username/83efe8c19b9dd6489167e67464030d04" /> <button onclick="">Load Github Gist</button>
+                                Import Github Gist (<a href="#gisthelp">info and help</a>) :  <input type="url" id="gisturl" placeholder="https://gist.github.com/username/83efe8c19b9dd6489167e67464030d04" /> <button onclick="loadGistFromUrl()">Load</button>
                             </p>
                         </li>
                     </ul>
@@ -579,6 +592,50 @@
                             instance of the clicked node.</p>
                     </li>
                 </ul>
+
+                <p>&nbsp;</p>
+
+                <h2 id="gisthelp">Publishing via Github Gists</h2>
+                <br/>
+                <p>
+                    You can load a PyNode script from Github's gists service. Gists are snippets of text or files that are public and stored on Github.
+                    They are useful for sharing small files with people. PyNode can load your script from a Gist so that you can just send somebody a link to show them a graph.
+                </p>
+
+                <br/>
+
+                <p>
+                    Below are instructions for uploading your PyNode script to Github and then using it.
+                </p>
+
+                <p>
+                    <ol>
+                        <li>
+                            Create a new Gist. If you have a Github account, <a href="https://gist.new" target="_blank">click here</a> to create a new Gist. If not, <a href=""https://github.com/join?return_to=https://gist.github.com/new&source=header-gist" target="_blank">click here</a> to sign up and create one.
+                        </li>
+
+                        <li>
+                            Paste your PyNode script here and press the "Save" button.
+                        </li>
+
+                        <li>
+                            Copy the URL of the page that you are taken to after you save your Gist.
+                        </li>
+
+                        <li>
+                            Enter the URL on the PyNode homepage and click 'Load'
+                        </li>
+
+                        <li>
+                            You should be taken to a page that shows the graph that you just created.
+                        </li>
+                    </ol>
+                </p>
+
+                <p>
+                    <b>Note</b>: This is not a two-way sync. If you edit the script in PyNode, the Gist will not be updated. You will need to update it within Github. Gists are more for publishing your script over saving it.
+                </p>
+
             </div>
             <div class="pageWhole" id="download">
                 <h1>Download</h1>

--- a/index.html
+++ b/index.html
@@ -112,43 +112,60 @@
         } else if (searchParams.get("gist")) {
 
             read_storage = false;
+
+            // Get the gist id from the url search params
             const gist_slug = searchParams.get("gist");
+            localStorage.setItem("code", "");
 
             // Should be in the form username-gistid
             // e.g. jdoe-83efe8c19b9dd6489167e67464030d04
             if (gist_slug.includes("-")) {
+
+                // Fetch the raw content of the gist
                 fetch(`https://gist.githubusercontent.com/${gist_slug.replace("-", "/")}/raw`).then(r => {
 
                     if (r.status == 200) {
+                        localStorage.removeItem("code");
                         return r.text()
                     } else {
                         read_storage = true;
                         if (editor_exists) {
-                            loadCode()
+                            loadCode("# Couldn't load gist  (http != 200).\n# Please try again later.\n\n")
                         }
                     }
 
                 }).then(t => {
                     if (t) {
+
+                        // Add a small prefix to inform the user whether the gist was loaded from the server or from local storage
                         editor_text = `# Content loaded from Github gist on ${new Date().toLocaleString()}\n# https://gist.github.com/${gist_slug.replace("-", "/")}\n\n${t}`;
 
                         if (editor_exists) {
                             editor.setValue(editor_text, -1);
+                            saveCode();
                         }
                     }
-                })
+                }).catch(e => {
+
+                    read_storage = true;
+                    if (editor_exists) {
+                        loadCode("# Couldn't load gist (fetch error).\n# Please try again later.\n\n")
+                    }
+
+                });
+
             } else {
                 read_storage = true;
                 if (editor_exists) {
-                    loadCode()
+                    loadCode("# Couldn't load gist (invalid gist slug).\n# Please try again later.\n\n")
                 }
             }
 
         }
 
-        var url = window.location.href;
-        var newUrl = url.substring(url.lastIndexOf('/') + 1).split("?")[0];
-        window.history.pushState("object or string", "Title", "" + newUrl);
+        // var url = window.location.href;
+        // var newUrl = url.substring(url.lastIndexOf('/') + 1).split("?")[0];
+        // window.history.pushState("object or string", "Title", "" + newUrl);
 
         function loadGistFromUrl() {
 
@@ -723,23 +740,28 @@
         localStorage.setItem("code", getCode())
     }
 
-    function loadCode() {
+    function loadCode(prefix) {
         src = localStorage.getItem("code");
         if (src === null || src == "") {
-            openCode("dijkstra");
+            openCode("dijkstra", prefix);
         }
+
+        if (prefix) {
+            src = prefix + src;
+        }
+
         else {
             editor.setValue(src, -1);
         }
     }
 
-    function openCode(name) {
+    function openCode(name, prefix) {
         var client = new XMLHttpRequest();
         client.open("GET", "pynode_projects/" + name + ".py");
         client.onreadystatechange = function () {
             if (client.readyState == 4) {
                 if (editor_exists) {
-                    editor.setValue(client.responseText, -1);
+                    editor.setValue((prefix || "") + client.responseText, -1);
                     saveCode();
                 }
             }

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
             const url = document.getElementById("gisturl").value;
             const slug = url.replace("https://gist.github.com/", "").replace("/", "-");
 
-            const newUrl = `${location.protocol}//${location.hostname}/?gist=${slug}`;
+            const newUrl = `${location.href.replace(window.location.search,"")}?gist=${slug}`;
             window.location.href = newUrl;
 
         }

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 
             console.log("Gist parameter found, value: " + gist_slug);
 
-            localStorage.setItem("code", "");
+            // localStorage.setItem("code", "");
 
             // Should be in the form username-gistid
             // e.g. jdoe-83efe8c19b9dd6489167e67464030d04
@@ -132,7 +132,7 @@
                     console.log("Response status: " + r.status);
 
                     if (r.status == 200) {
-                        localStorage.setItem("code", "");
+                        // localStorage.setItem("code", "");
                         return r.text()
                     } else {
                         read_storage = true;

--- a/js/greuler/greuler.js
+++ b/js/greuler/greuler.js
@@ -1154,10 +1154,21 @@
                 }, {
                     key: 'unit',
                     value: function unit(a) {
+                        var length;
                         if (a.x === 0 && a.y === 0) {
-                            throw Error('the length of the vector is 0');
+                            // Basically, this error sometimes gets thrown when you're trying to 
+                            // specifically set the position of the nodes in PyNode. It's super
+                            // annoying and is thrown through a bunch of nested functions so, along
+                            // with the Python -> JS transpilation it's almost impossible to find
+                            // the actual reason why the error matters. So I am just removing it and
+                            // hardcoding a very small vector length so a DivisionByZero error doesn't
+                            // occur. This probably isn't good code or anything but I have tested it
+                            // and it seems to work.
+                            // throw Error('the length of the vector is 0');
+                            length = 0.0001;
+                        } else {
+                            length = this.len(a);
                         }
-                        var length = this.len(a);
                         return new Vector(a.x / length, a.y / length);
                     }
                 }, {


### PR DESCRIPTION
Currently, there is no mechanism in PyNode to publish your code so that it can be viewed by others. In VCE Algorithmics, I feel like it would be helpful to have this option so that I can send just a link to my teacher instead of code that would have to be manually copied and pasted into PyNode.

Since it would be a little out of scope to actually implement a full saving and publishing system, instead I have updated the website in this PR to include Github Gist support. They are a simple way of sharing small files (like PyNode scripts) and integration with the website is very easy.

For an example of how this feature is going to work, I have made this gist: https://gist.github.com/shaunakg/fef1d03e5f084b0a6c60aa3d8734ffb2. Using the built-in option on the website, I can easily create a PyNode URL that loads that Gist: http://alexsocha.github.io/pynode?gist=shaunakg-fef1d03e5f084b0a6c60aa3d8734ffb2. I can send this to my teacher or whoever and they can click on it to view my graph.

Loading it takes <1 second and is pretty much seamless for the user. Since PyNode also caches the last thing that was in the editor the loaded-in content also has a timestamp for ease of use.

This PR should be 100% good to go and ready to merge (I have also added some help and documentation in case it is needed). I can answer any questions if you have them. 